### PR TITLE
Fixing build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AssetManager
 By [Wesley Overdijk](http://blog.spoonx.nl/) and [Marco Pivetta](http://ocramius.github.com/)
 
-[![Build Status](https://secure.travis-ci.org/RWOverdijk/AssetManager.png)](http://travis-ci.org/RWOverdijk/AssetManager)
+[![Build Status](https://secure.travis-ci.org/RWOverdijk/AssetManager.png?branch=master)](http://travis-ci.org/RWOverdijk/AssetManager)
 
 ## Introduction
 This module is intended for usage with a default directory structure of a


### PR DESCRIPTION
Build status icon was referencing last build, should reference `master`
