### PR TITLE
Fix for console

### DIFF
--- a/src/AssetManager/Module.php
+++ b/src/AssetManager/Module.php
@@ -51,7 +51,7 @@ class Module implements
     public function onDispatch(EventInterface $event)
     {
         $response = $event->getResponse();
-        if ($response->getStatusCode() !== 404) {
+        if (!method_exists($response, 'getStatusCode') || $response->getStatusCode() !== 404) {
             return;
         }
         $request        = $event->getRequest();


### PR DESCRIPTION
**Adding unit tests in next PR**

When used in combination with console, a fatal was thrown. Simple explanation: missing method (getStatusCode).
