### PR TITLE
Fix for AssetManager issue 69

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.0.*",
+        "zendframework/zendframework": "2.*",
         "kriswallsmith/assetic": ">=v1.1.0-alpha1"
     },
     "autoload": {


### PR DESCRIPTION
Don't constrain ZF usage to 2.0 branch so that 2.1-dev can be used, and so in future...
