### PR TITLE
Support to call filter constructor with arguments

### DIFF
--- a/src/AssetManager/Service/AssetFilterManager.php
+++ b/src/AssetManager/Service/AssetFilterManager.php
@@ -84,7 +84,7 @@ class AssetFilterManager implements ServiceLocatorAwareInterface, MimeResolverAw
 
         foreach ($filters as $filter) {
             if (!empty($filter['filter'])) {
-                $this->ensureByFilter($asset, $filter['filter'], $filter['args']);
+                $this->ensureByFilter($asset, $filter['filter'],array_key_exists('args',$filter) ? $filter['args'] : array());
             } elseif(!empty($filter['service'])) {
                 $this->ensureByService($asset, $filter['service']);
             } else {


### PR DESCRIPTION
In Assetic, the Yui\BaseCompressorFilter constructor takes two arguments.

Calling filter constructor with arguments wasn't supported.

Configuration example :
        'filters' => array(
            'text/css' => array(
                array(
                    'filter' => 'Yui\CssCompressorFilter',
                    'args' => array(
                        'jarPath' => **DIR** . '/../library/yuicompressor-2.4.8pre.jar',
                        'javaPath' => 'java',
                    ),
                ),
            ),
        ),
