### PR TITLE
[BC Break Fix] Test suite issues due to PR #106

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,11 @@
         "zendframework/zend-eventmanager": "2.*",
         "zendframework/zend-modulemanager": "2.*",
         "zendframework/zend-mvc": "2.*",
+        "zendframework/zend-view": "2.*",
+        "zendframework/zend-config": "2.*",
+        "zendframework/zend-form": "2.*",
+        "zendframework/zend-serializer": "2.*",
+        "zendframework/zend-console": "2.*",
         "kriswallsmith/assetic": "1.1.*"
     },
     "autoload": {


### PR DESCRIPTION
**Summary:** PR #106 accidentally broke the test suite without realizing it. This PR will fix it, but will show up as failing in Travis until it is merged (due to the problem introduced by #106). You just have to trust me. :)

---

After following the instructions in `.travis.yml` to get the test suite working in order to work on a separate bug fix, I was getting this error:

> PHP Fatal error:  Class 'Zend\Config\Factory' not found in /Users/mmoussa/projects/personal/ZendSkeletonApplication/vendor/zendframework/zend-modulemanager/Zend/ModuleManager/Listener/ConfigListener.php on line 348

I thought this was really strange because I was working off of a checkout of `master`, which was showing the "Build Passing" badge from Travis. I went over to the Travis interface for AssetManager and found that the latest build run was actually broken with the same error I was getting: https://travis-ci.org/RWOverdijk/AssetManager/jobs/13335219

However, the build that was run for the last commit against `master` worked fine: https://travis-ci.org/RWOverdijk/AssetManager/builds/11310997.

How can this be? I looked at the diff for that last commit: https://github.com/jmleroux/AssetManager/commit/19c8949d6b45ef70bf9c5c2e84d77f3659d649d2

The full ZF2 dependency was removed and replaced with just specific modules. This would normally be absolutely fine, BUT, have a look at this: https://github.com/RWOverdijk/AssetManager/blob/master/.travis.yml#L11-L13 and https://github.com/RWOverdijk/AssetManager/blob/master/.travis/composer.json#L3.

So, Travis copies `.travis/composer.json` over from the `AssetManager` clone and then runs `composer install`. The new `composer.json` references `"rwoverdijk/assetmanager": "*@dev"`, which **at the time that last build was run** still included the full `zendframework/zendframework` dependency. The reason it is failing now is because Composer is installing from the **new** `composer.json` file which includes an incomplete list of modules (missing `zend-config` and some other modules)! Given how the test suite setup is done, I don't think it would have been possible to easily realize this would break at the time.

This PR will fix this problem, but **since the composer.json currently in `master` is incorrect, the Travis build WILL fail** until it is merged.

I know this is a huge wall of text, so I hope I did a good job of explaining the problem. If you are not convinced and want to see what I mean, have Travis run a new build against `master`. It will certainly fail. The other three PRs are also failing, even #108 which is just a README.md change.
