### PR TITLE
Fixes PSR2 errors for php-cs-fixer

### DIFF
--- a/src/AssetManager/Cache/FilePathCache.php
+++ b/src/AssetManager/Cache/FilePathCache.php
@@ -66,7 +66,7 @@ class FilePathCache implements CacheInterface
     {
         $cacheDir = dirname($this->cachedFile());
 
-        set_error_handler(function($errno, $errstr) {
+        set_error_handler(function ($errno, $errstr) {
             if ($errstr !== 'mkdir(): File exists') {
                 throw new \RuntimeException($errstr);
             }
@@ -95,7 +95,7 @@ class FilePathCache implements CacheInterface
      */
     public function remove($key)
     {
-        set_error_handler(function($errno, $errstr) {
+        set_error_handler(function ($errno, $errstr) {
             throw new \RuntimeException($errstr);
         });
 

--- a/src/AssetManager/Service/AssetCacheManager.php
+++ b/src/AssetManager/Service/AssetCacheManager.php
@@ -81,7 +81,7 @@ class AssetCacheManager
         } else {
             // @codeCoverageIgnoreStart
             $factories  = array(
-                'FilesystemCache' => function($options) {
+                'FilesystemCache' => function ($options) {
                     if (empty($options['dir'])) {
                         throw new Exception\RuntimeException(
                             'FilesystemCache expected dir entry.'
@@ -90,10 +90,10 @@ class AssetCacheManager
                     $dir = $options['dir'];
                     return new Cache\FilesystemCache($dir);
                 },
-                'ApcCache' => function($options) {
+                'ApcCache' => function ($options) {
                     return new Cache\ApcCache();
                 },
-                'FilePathCache' => function($options) use ($path) {
+                'FilePathCache' => function ($options) use ($path) {
                     if (empty($options['dir'])) {
                         throw new Exception\RuntimeException(
                             'FilePathCache expected dir entry.'

--- a/tests/AssetManagerTest/Resolver/CollectionResolverTest.php
+++ b/tests/AssetManagerTest/Resolver/CollectionResolverTest.php
@@ -260,7 +260,7 @@ class CollectionsResolverTest extends PHPUnit_Framework_TestCase
     public function testMimeTypesDontMatch()
     {
         $callbackInvocationCount = 0;
-        $callback = function() use (&$callbackInvocationCount) {
+        $callback = function () use (&$callbackInvocationCount) {
 
             $asset1 = new Asset\StringAsset('bacon');
             $asset2 = new Asset\StringAsset('eggs');
@@ -375,7 +375,7 @@ class CollectionsResolverTest extends PHPUnit_Framework_TestCase
     public function testSuccessResolve()
     {
         $callbackInvocationCount = 0;
-        $callback = function() use (&$callbackInvocationCount) {
+        $callback = function () use (&$callbackInvocationCount) {
 
             $asset1 = new Asset\StringAsset('bacon');
             $asset2 = new Asset\StringAsset('eggs');

--- a/tests/AssetManagerTest/Service/AssetManagerTest.php
+++ b/tests/AssetManagerTest/Service/AssetManagerTest.php
@@ -424,7 +424,7 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
         $config = array(
             'caching' => array(
                 'asset-path' => array(
-                    'cache' => function($file) {
+                    'cache' => function ($file) {
                         return new FilePathCache('/tmp', $file);
                     },
                 ),
@@ -451,7 +451,7 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
         $config = array(
             'caching' => array(
                 'asset-path' => array(
-                    'cache' => function($file) {
+                    'cache' => function ($file) {
                         return new \stdClass;
                     },
                 ),


### PR DESCRIPTION
Fixes [Travis errors](https://travis-ci.org/RWOverdijk/AssetManager/jobs/14932653#L182):

```
$ output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
1) tests/AssetManagerTest/Service/AssetManagerTest.php (function_declaration)
2) tests/AssetManagerTest/Resolver/CollectionResolverTest.php (function_declaration)
3) src/AssetManager/Service/AssetCachanager.php (function_declaration)
4) src/AssetManager/Cache/FilePathCache.php (function_declaration)
```
