### PR TITLE
Achieve atomic cache writes

### DIFF
--- a/src/AssetManager/Cache/FilePathCache.php
+++ b/src/AssetManager/Cache/FilePathCache.php
@@ -87,7 +87,10 @@ class FilePathCache implements CacheInterface
             throw new \RuntimeException('Unable to write file ' . $this->cachedFile());
         }
 
-        file_put_contents($this->cachedFile(), $value);
+        // Use "rename" to achieve atomic writes
+        $tmpFilePath = $cacheDir . '/' . uniqid('AssetManagerFilePathCache');
+        file_put_contents($tmpFilePath, $value);
+        rename($tmpFilePath, $this->cachedFile());
     }
 
     /**


### PR DESCRIPTION
`file_put_contents(...)` is not atomic and may cause issues on highly trafficked sites with the target files being read before they've been written completely and thus cached truncated.
