### PR TITLE
Stop event propagation on successful Asset Response

### DIFF
--- a/src/AssetManager/Module.php
+++ b/src/AssetManager/Module.php
@@ -63,6 +63,7 @@ class Module implements
             return;
         }
 
+        $event->stopPropagation();
         $response->setStatusCode(200);
 
         return $assetManager->setAssetOnResponse($response);


### PR DESCRIPTION
Unlike EVENT_DISPATCH, EVENT_DISPATCH_ERROR does not short circuit and stop propagation automatically when a listener returns a Response object. Therefore, problems can occur if another listener is registered at a lower priority than AssetManager. In the case where AssetManager succeeds and returns a Response containing an Asset, the lower level listener will cause a broken link unless it also returns the Response.

I'm open to reasons as to whether or not stopping propagation might be a good idea here? The problem can be solved by having the module below return the (unchanged) Response but I wondered whether this should be necessary and whether AssetManager should be stopping event propagation (and therefore stop control reaching the lower module listener)?