### PR TITLE
Fix temporary file naming collision in FilePathCache

### DIFF
--- a/src/AssetManager/Cache/FilePathCache.php
+++ b/src/AssetManager/Cache/FilePathCache.php
@@ -66,7 +66,9 @@ class FilePathCache implements CacheInterface
      */
     public function set($key, $value)
     {
-        $cacheDir = dirname($this->cachedFile());
+        $pathInfo = pathInfo($this->cachedFile());
+        $cacheDir = $pathInfo['dirname'];
+        $fileName = $pathInfo['filename'];
 
         ErrorHandler::start();
 
@@ -86,9 +88,11 @@ class FilePathCache implements CacheInterface
         }
 
         // Use "rename" to achieve atomic writes
-        $tmpFilePath = $cacheDir . '/' . uniqid('AssetManagerFilePathCache');
-        file_put_contents($tmpFilePath, $value);
-        rename($tmpFilePath, $this->cachedFile());
+        $tmpFilePath = $cacheDir . '/'.$fileName.'_'. uniqid('AssetManagerFilePathCache', true);
+
+        if (@file_put_contents($tmpFilePath, $value, LOCK_EX) !== false) {
+            rename($tmpFilePath, $this->cachedFile());
+        }
     }
 
     /**

--- a/src/AssetManager/Cache/FilePathCache.php
+++ b/src/AssetManager/Cache/FilePathCache.php
@@ -68,7 +68,7 @@ class FilePathCache implements CacheInterface
     {
         $pathInfo = pathInfo($this->cachedFile());
         $cacheDir = $pathInfo['dirname'];
-        $fileName = $pathInfo['filename'];
+        $fileName = $pathInfo['basename'];
 
         ErrorHandler::start();
 
@@ -88,7 +88,7 @@ class FilePathCache implements CacheInterface
         }
 
         // Use "rename" to achieve atomic writes
-        $tmpFilePath = $cacheDir . '/'.$fileName.'_'. uniqid('AssetManagerFilePathCache', true);
+        $tmpFilePath = $cacheDir . '/AssetManagerFilePathCache_'.$fileName;
 
         if (@file_put_contents($tmpFilePath, $value, LOCK_EX) !== false) {
             rename($tmpFilePath, $this->cachedFile());

--- a/src/AssetManager/Cache/FilePathCache.php
+++ b/src/AssetManager/Cache/FilePathCache.php
@@ -55,7 +55,7 @@ class FilePathCache implements CacheInterface
         $path = $this->cachedFile();
 
         if (!file_exists($path)) {
-            throw new \RuntimeException('There is no cached value for ' . $this->filename);
+            throw new RuntimeException('There is no cached value for ' . $this->filename);
         }
 
         return file_get_contents($path);
@@ -84,14 +84,14 @@ class FilePathCache implements CacheInterface
         ErrorHandler::stop();
 
         if (!is_writable($cacheDir)) {
-            throw new \RuntimeException('Unable to write file ' . $this->cachedFile());
+            throw new RuntimeException('Unable to write file ' . $this->cachedFile());
         }
 
         // Use "rename" to achieve atomic writes
         $tmpFilePath = $cacheDir . '/AssetManagerFilePathCache_' . $fileName;
 
         if (@file_put_contents($tmpFilePath, $value, LOCK_EX) === false) {
-            throw new \RuntimeException('Unable to write file ' . $this->cachedFile());
+            throw new RuntimeException('Unable to write file ' . $this->cachedFile());
         }
 
         rename($tmpFilePath, $this->cachedFile());

--- a/src/AssetManager/Cache/FilePathCache.php
+++ b/src/AssetManager/Cache/FilePathCache.php
@@ -88,11 +88,13 @@ class FilePathCache implements CacheInterface
         }
 
         // Use "rename" to achieve atomic writes
-        $tmpFilePath = $cacheDir . '/AssetManagerFilePathCache_'.$fileName;
+        $tmpFilePath = $cacheDir . '/AssetManagerFilePathCache_' . $fileName;
 
-        if (@file_put_contents($tmpFilePath, $value, LOCK_EX) !== false) {
-            rename($tmpFilePath, $this->cachedFile());
+        if (@file_put_contents($tmpFilePath, $value, LOCK_EX) === false) {
+            throw new \RuntimeException('Unable to write file ' . $this->cachedFile());
         }
+
+        rename($tmpFilePath, $this->cachedFile());
     }
 
     /**

--- a/tests/AssetManagerTest/Cache/FilePathCacheTest.php
+++ b/tests/AssetManagerTest/Cache/FilePathCacheTest.php
@@ -88,6 +88,28 @@ class FilePathCacheTest extends PHPUnit_Framework_TestCase
 
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testSetCanNotWriteToFileThatExists()
+    {
+        restore_error_handler(); // Previous test fails, so doesn't unset.
+        $time = time()+333;
+        $sentence = 'I am, what I am. Cached data, please don\'t hate, '
+            . 'for we are all equals. Except you, you\'re a dick.';
+        $base = '/tmp/_cachetest.' . $time . '/';
+        mkdir($base, 0777);
+
+        $fileName = 'sausage.'.$time.'.iceicebaby';
+
+        touch($base.'AssetManagerFilePathCache_' . $fileName);
+        chmod($base.'AssetManagerFilePathCache_' . $fileName, 0400);
+
+        $cache = new FilePathCache($base, $fileName);
+
+        $cache->set('bacon', $sentence);
+    }
+
     public function testSetSuccess()
     {
         $time       = time();


### PR DESCRIPTION
Currently the FilePathCache suffers from occasional filename collisions when creating the temporary file for the asset.  This causes a couple of issues.   First the temporary file referenced is no longer a cache of the expected file.  Two, due to no file lock on the file, the temporary file becomes a hybrid of the expected cache file + the output of another cache file.

While this doesn't happen very often it has happened enough in our production environment to cause some major headaches and loss of revenue.

This fix attempts to address naming collisions with the temporary file created during the caching process.  In addition also adds and exclusive write lock to the file during the writing process.  If for some reason this write fails, it will fail silently and will have to be cached on the next request.