### PR TITLE
Remove deprecated ServiceLocatorAwareInterface

### DIFF
--- a/src/AssetManager/Service/AssetFilterManager.php
+++ b/src/AssetManager/Service/AssetFilterManager.php
@@ -5,12 +5,10 @@ namespace AssetManager\Service;
 use Assetic\Asset\AssetInterface;
 use Assetic\Filter\FilterInterface;
 use AssetManager\Exception;
-use AssetManager\Service\MimeResolver;
 use AssetManager\Resolver\MimeResolverAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
 
-class AssetFilterManager implements ServiceLocatorAwareInterface, MimeResolverAwareInterface
+class AssetFilterManager implements MimeResolverAwareInterface
 {
     /**
      * @var array Filter configuration.


### PR DESCRIPTION
The service locator is manually injected by `AssetFilterManagerServiceFactory` anyway.