### PR TITLE
Use of current timestamp as view helper's query param as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ return array(
             ),
         ),
         'view_helper' => array(
-            // Note: You will need to require the factory used for the cache yourself.
-            'cache'        => 'Application\Cache\Redis',
+            'cache'            => 'Application\Cache\Redis', // You will need to require the factory used for the cache yourself.
+            'append_timestamp' => true,                      // optional, if false never append a query param
+            'query_string'     => '_',                       // optional
         ),
         'caching' => array(
             'js/d.js' => array(

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -32,9 +32,9 @@ return array(
             'AssetManager\Resolver\PathStackResolver'           => 500,
         ),
         'view_helper' => array(
-            'cache'            => null,
+            'append_timestamp' => true,
             'query_string'     => '_',
-            'development_mode' => false,
+            'cache'            => null,
         ),
     ),
     'controllers'     => array(

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -31,6 +31,11 @@ return array(
             'AssetManager\Resolver\AliasPathStackResolver'      => 1000,
             'AssetManager\Resolver\PathStackResolver'           => 500,
         ),
+        'view_helper' => array(
+            'cache'            => null,
+            'query_string'     => '_',
+            'development_mode' => false,
+        ),
     ),
     'controllers'     => array(
         'factories' => array(

--- a/src/AssetManager/View/Helper/Asset.php
+++ b/src/AssetManager/View/Helper/Asset.php
@@ -32,14 +32,17 @@ class Asset extends AbstractHelper
     /**
      * Append timestamp as query param to the filename
      *
-     * @param string $filename
-     * @param string $queryString
-     * @param string $timestamp
+     * @param string   $filename
+     * @param string   $queryString
+     * @param int|null $timestamp
      *
      * @return string
      */
-    private function appendTimestamp($filename, $queryString, $timestamp)
+    private function appendTimestamp($filename, $queryString, $timestamp = null)
     {
+        // current timestamp as default
+        $timestamp = $timestamp === null ? time() : $timestamp;
+
         return $filename . '?' . urlencode($queryString) . '=' . $timestamp;
     }
 
@@ -119,7 +122,7 @@ class Asset extends AbstractHelper
                 && $this->config['view_helper']['development_mode'] === true) {
 
                 // append current timestamp to the filepath and use a custom query string
-                return $this->appendTimestamp($filename, $queryString, time());
+                return $this->appendTimestamp($filename, $queryString);
             }
 
             return $filename;

--- a/src/AssetManager/View/Helper/Asset.php
+++ b/src/AssetManager/View/Helper/Asset.php
@@ -118,8 +118,7 @@ class Asset extends AbstractHelper
         if (!isset($cacheConfig['options']['dir'])) {
 
             // development mode enabled
-            if (isset($this->config['view_helper']['development_mode'])
-                && $this->config['view_helper']['development_mode'] === true) {
+            if (!empty($this->config['view_helper']['development_mode'])) {
 
                 // append current timestamp to the filepath and use a custom query string
                 return $this->appendTimestamp($filename, $queryString);

--- a/src/AssetManager/View/Helper/Asset.php
+++ b/src/AssetManager/View/Helper/Asset.php
@@ -30,6 +30,20 @@ class Asset extends AbstractHelper
     }
 
     /**
+     * Append timestamp as query param to the filename
+     *
+     * @param string $filename
+     * @param string $queryString
+     * @param string $timestamp
+     *
+     * @return string
+     */
+    private function appendTimestamp($filename, $queryString, $timestamp)
+    {
+        return $filename . '?' . urlencode($queryString) . '=' . $timestamp;
+    }
+
+    /**
      * find the file and if it exists, append its unix modification time to the filename
      *
      * @param string $filename
@@ -42,7 +56,7 @@ class Asset extends AbstractHelper
         if ($asset !== null) {
 
             // append last modified date to the filepath and use a custom query string
-            return $filename . '?' . urlencode($queryString) . '=' . $asset->getLastModified();
+            return $this->appendTimestamp($filename, $queryString, $asset->getLastModified());
         }
 
         return $filename;
@@ -92,15 +106,24 @@ class Asset extends AbstractHelper
             $cacheConfig = $this->config['caching']['default'];
         }
 
-        // if nothing done, return the original filename
-        if (!isset($cacheConfig['options']['dir'])) {
-            return $filename;
-        }
-
         // query string params
         $queryString = isset($this->config['view_helper']['query_string'])
             ? $this->config['view_helper']['query_string']
             : '_';
+
+        // if nothing done, return the original filename
+        if (!isset($cacheConfig['options']['dir'])) {
+
+            // development mode enabled
+            if (isset($this->config['view_helper']['development_mode'])
+                && $this->config['view_helper']['development_mode'] === true) {
+
+                // append current timestamp to the filepath and use a custom query string
+                return $this->appendTimestamp($filename, $queryString, time());
+            }
+
+            return $filename;
+        }
 
         // get the filePath from the cache (if available)
         $filePath = $this->getFilePathFromCache($filename, $queryString);

--- a/src/AssetManager/View/Helper/Asset.php
+++ b/src/AssetManager/View/Helper/Asset.php
@@ -102,6 +102,11 @@ class Asset extends AbstractHelper
      */
     public function __invoke($filename)
     {
+        // nothing to append
+        if (empty($this->config['view_helper']['append_timestamp'])) {
+            return $filename;
+        }
+        
         // search the cache config for the specific file requested (if none, use the default one)
         if (isset($this->config['caching'][$filename])) {
             $cacheConfig = $this->config['caching'][$filename];
@@ -114,17 +119,11 @@ class Asset extends AbstractHelper
             ? $this->config['view_helper']['query_string']
             : '_';
 
-        // if nothing done, return the original filename
+        // no cache dir is defined
         if (!isset($cacheConfig['options']['dir'])) {
 
-            // development mode enabled
-            if (!empty($this->config['view_helper']['development_mode'])) {
-
-                // append current timestamp to the filepath and use a custom query string
-                return $this->appendTimestamp($filename, $queryString);
-            }
-
-            return $filename;
+            // append current timestamp to the filepath and use a custom query string
+            return $this->appendTimestamp($filename, $queryString);
         }
 
         // get the filePath from the cache (if available)

--- a/tests/AssetManagerTest/View/Helper/AssetTest.php
+++ b/tests/AssetManagerTest/View/Helper/AssetTest.php
@@ -24,18 +24,27 @@ class AssetTest extends TestCase
 
     public function testInvoke()
     {
-        $config = array(
+        $configWithCache = array(
             'view_helper' => array(
-                'query_string' => '_',
-                'cache'        => null,
+                'query_string'     => '_',
+                'cache'            => null,
+                'development_mode' => false,
             ),
             'caching' => array(
                 'default' => array(
-                    'cache'     => 'AssetManager\Cache\FilePathCache',
+                    'cache' => 'AssetManager\Cache\FilePathCache',
                     'options' => array(
                         'dir' => 'public/assets',
                     ),
                 ),
+            ),
+        );
+
+        $configWithoutCache = array(
+            'view_helper' => array(
+                'query_string'     => '_',
+                'cache'            => null,
+                'development_mode' => false,
             ),
         );
 
@@ -47,18 +56,24 @@ class AssetTest extends TestCase
             'porn-food/bac.on' => __FILE__,
         ));
 
-        $helper = new Asset($resolver, null, $config);
-        $newFilename = $helper->__invoke($filename);
+        $helperWithCache = new Asset($resolver, null, $configWithCache);
+        $newFilename = $helperWithCache->__invoke($filename);
 
         $this->assertContains('?_=', $newFilename);
+
+        $helperWithoutCache = new Asset($resolver, null, $configWithoutCache);
+        $newFilename = $helperWithoutCache->__invoke($filename);
+
+        $this->assertNotContains('?_=', $newFilename);
     }
 
     public function testSameResultWithoutCachingConfig()
     {
         $config = array(
             'view_helper' => array(
-                'query_string' => '_',
-                'cache'        => null,
+                'query_string'     => '_',
+                'cache'            => null,
+                'development_mode' => false,
             ),
         );
 
@@ -74,5 +89,29 @@ class AssetTest extends TestCase
         $newFilename = $helper->__invoke($filename);
 
         $this->assertSame($newFilename, $filename);
+    }
+
+    public function testDevelopmentModeWithoutCache()
+    {
+        $config = array(
+            'view_helper' => array(
+                'query_string'     => '_',
+                'cache'            => null,
+                'development_mode' => true,
+            ),
+        );
+
+        $filename = 'porn-food/bac.on';
+
+        $resolver = $this->getGenericResolver();
+
+        $resolver->setMap(array(
+            'porn-food/bac.on' => __FILE__,
+        ));
+
+        $helper = new Asset($resolver, null, $config);
+        $newFilename = $helper->__invoke($filename);
+
+        $this->assertContains('?_=', $newFilename);
     }
 }


### PR DESCRIPTION
Always append current timestamp to filepaths if development mode in view helper is enabled