### PR TITLE
Missing external fully qualified name in AssetViewHelperFactory

### DIFF
--- a/src/AssetManager/Service/AssetViewHelperFactory.php
+++ b/src/AssetManager/Service/AssetViewHelperFactory.php
@@ -4,12 +4,12 @@ namespace AssetManager\Service;
 
 use AssetManager\Exception\InvalidArgumentException;
 use AssetManager\Resolver\ResolverInterface;
-use AssetManager\Service\AssetManager;
 use AssetManager\View\Helper\Asset;
 use Interop\Container\ContainerInterface;
 use Zend\Cache\Storage\Adapter\AbstractAdapter as AbstractCacheAdapter;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 
 class AssetViewHelperFactory implements FactoryInterface
 {


### PR DESCRIPTION
- Added important `use` of `Zend\ServiceManager\AbstractPluginManager`
- Removed unused `use` of `AssetManager\Service\AssetManager`

Second part is not important, but without the `use` of `Zend\ServiceManager\AbstractPluginManager`, the projects breaks.

@RWOverdijk I think it's very important, after upgrading to v1.7.0 today, it broke everything :P

https://www.dropbox.com/s/weiookkt2wr7gcy/Screenshot%202016-08-22%2012.56.10.png?dl=0