### PR TITLE
Fix for failing tests on Windows

### DIFF
--- a/tests/AssetManagerTest/Resolver/AliasPathStackResolverTest.php
+++ b/tests/AssetManagerTest/Resolver/AliasPathStackResolverTest.php
@@ -324,7 +324,7 @@ class AliasPathStackResolverTest extends PHPUnit_Framework_TestCase
     {
         $alias    = 'my/alias/';
         $resolver = new AliasPathStackResolver(array($alias => realpath(__DIR__ . '/../')));
-        $dir      = substr(__DIR__, strrpos(__DIR__, '/', 0) + 1);
+        $dir      = substr(__DIR__, strrpos(__DIR__, DIRECTORY_SEPARATOR, 0) + 1);
 
         $this->assertContains($alias . $dir . DIRECTORY_SEPARATOR . basename(__FILE__), $resolver->collect());
         $this->assertNotContains($alias . $dir . DIRECTORY_SEPARATOR . 'i-do-not-exist.php', $resolver->collect());

--- a/tests/AssetManagerTest/Resolver/PathStackResolverTest.php
+++ b/tests/AssetManagerTest/Resolver/PathStackResolverTest.php
@@ -163,7 +163,7 @@ class PathStackResolverTest extends PHPUnit_Framework_TestCase
     {
         $resolver = new PathStackResolver();
         $resolver->addPath(realpath(__DIR__ . '/../'));
-        $dir = substr(__DIR__, strrpos(__DIR__, '/', 0) + 1);
+        $dir = substr(__DIR__, strrpos(__DIR__, DIRECTORY_SEPARATOR, 0) + 1);
 
         $this->assertContains($dir . DIRECTORY_SEPARATOR . basename(__FILE__), $resolver->collect());
         $this->assertNotContains($dir . DIRECTORY_SEPARATOR . 'i-do-not-exist.php', $resolver->collect());

--- a/tests/AssetManagerTest/Resolver/PrioritizedPathsResolverTest.php
+++ b/tests/AssetManagerTest/Resolver/PrioritizedPathsResolverTest.php
@@ -248,7 +248,7 @@ class PrioritizedPathsResolverTest extends PHPUnit_Framework_TestCase
     {
         $resolver = new PrioritizedPathsResolver();
         $resolver->addPath(realpath(__DIR__ . '/../'));
-        $dir = substr(__DIR__, strrpos(__DIR__, '/', 0) + 1);
+        $dir = substr(__DIR__, strrpos(__DIR__, DIRECTORY_SEPARATOR, 0) + 1);
 
         $this->assertContains($dir . DIRECTORY_SEPARATOR . basename(__FILE__), $resolver->collect());
         $this->assertNotContains($dir . DIRECTORY_SEPARATOR . 'i-do-not-exist.php', $resolver->collect());

--- a/tests/AssetManagerTest/Service/PathStackResolverServiceFactoryTest.php
+++ b/tests/AssetManagerTest/Service/PathStackResolverServiceFactoryTest.php
@@ -34,8 +34,8 @@ class PathStackResolverServiceFactoryTest extends PHPUnit_Framework_TestCase
         $resolver = $factory->createService($serviceManager);
         $this->assertSame(
             array(
-                'path2/',
-                'path1/',
+                'path2' . DIRECTORY_SEPARATOR,
+                'path1' . DIRECTORY_SEPARATOR,
             ),
             $resolver->getPaths()->toArray()
         );


### PR DESCRIPTION
Some tests were failing on my Windows machine. They all had problems with `DIRECTORY_SEPARATOR`.