### PR TITLE
Improve view helper declaration

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -44,9 +44,12 @@ return [
         ],
     ],
     'view_helpers'    => [
-        'factories' => [
-            'asset' => AssetManager\Service\AssetViewHelperFactory::class,
+        'aliases' => [
+            'asset' => AssetManager\View\Helper\Asset::class
         ],
+        'factories' => [
+            AssetManager\View\Helper\Asset::class => AssetManager\Service\AssetViewHelperFactory::class
+        ]
     ],
     'console'         => [
         'router' => [

--- a/tests/AssetManagerTest/View/Helper/AssetTest.php
+++ b/tests/AssetManagerTest/View/Helper/AssetTest.php
@@ -7,6 +7,9 @@ use AssetManager\Resolver\MimeResolverAwareInterface;
 use AssetManager\Service\MimeResolver;
 use AssetManager\View\Helper\Asset;
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+use Zend\View\HelperPluginManager;
 
 class AssetTest extends TestCase
 {
@@ -127,21 +130,25 @@ class AssetTest extends TestCase
     {
         $config = require 'config/module.config.php';
         
-        $serviceManager = new \Zend\ServiceManager\ServiceManager($config['service_manager']);
-        $serviceManager->setService('config',$config);
+        $serviceConfig = new Config($config['service_manager']);
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('config', $config);
+        $serviceConfig->configureServiceManager($serviceManager);
         
-        $pluginManager = new \Zend\View\HelperPluginManager($serviceManager,$config['view_helpers']);
-        $this->assertInstanceOf(\AssetManager\View\Helper\Asset::class,$pluginManager->get(\AssetManager\View\Helper\Asset::class));
+        $pluginManager = new HelperPluginManager($serviceManager, $config['view_helpers']);
+        $this->assertInstanceOf(Asset::class, $pluginManager->get(Asset::class));
     }
     
     public function testRetrieveHelperFromPluginManagerByAlias()
     {
         $config = require 'config/module.config.php';
         
-        $serviceManager = new \Zend\ServiceManager\ServiceManager($config['service_manager']);
-        $serviceManager->setService('config',$config);
+        $serviceConfig = new Config($config['service_manager']);
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('config', $config);
+        $serviceConfig->configureServiceManager($serviceManager);
         
-        $pluginManager = new \Zend\View\HelperPluginManager($serviceManager,$config['view_helpers']);
-        $this->assertInstanceOf(\AssetManager\View\Helper\Asset::class,$pluginManager->get('asset'));
+        $pluginManager = new HelperPluginManager($serviceManager, $config['view_helpers']);
+        $this->assertInstanceOf(Asset::class, $pluginManager->get('asset'));
     }
 }

--- a/tests/AssetManagerTest/View/Helper/AssetTest.php
+++ b/tests/AssetManagerTest/View/Helper/AssetTest.php
@@ -122,4 +122,26 @@ class AssetTest extends TestCase
         $this->assertNotContains('?_=', $newFilename);
         $this->assertSame($newFilename, $filename);
     }
+    
+    public function testRetrieveHelperFromPluginManagerByClassConstant()
+    {
+        $config = require 'config/module.config.php';
+        
+        $serviceManager = new \Zend\ServiceManager\ServiceManager($config['service_manager']);
+        $serviceManager->setService('config',$config);
+        
+        $pluginManager = new \Zend\View\HelperPluginManager($serviceManager,$config['view_helpers']);
+        $this->assertInstanceOf(\AssetManager\View\Helper\Asset::class,$pluginManager->get(\AssetManager\View\Helper\Asset::class));
+    }
+    
+    public function testRetrieveHelperFromPluginManagerByAlias()
+    {
+        $config = require 'config/module.config.php';
+        
+        $serviceManager = new \Zend\ServiceManager\ServiceManager($config['service_manager']);
+        $serviceManager->setService('config',$config);
+        
+        $pluginManager = new \Zend\View\HelperPluginManager($serviceManager,$config['view_helpers']);
+        $this->assertInstanceOf(\AssetManager\View\Helper\Asset::class,$pluginManager->get('asset'));
+    }
 }


### PR DESCRIPTION
Allow view helper to be accessed based on class constant name. Add alias for backwards compatibility.

I was having trouble with the 'asset' alias pulling out the zend-view helper rather than the helper in this module.