### PR TITLE
Fix ViewHelper Configuration

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -45,8 +45,11 @@ return [
     ],
     'view_helpers'    => [
         'factories' => [
-            'asset' => AssetManager\Service\AssetViewHelperFactory::class,
+            AssetManager\View\Helper\Asset::class => AssetManager\Service\AssetViewHelperFactory::class
         ],
+        'aliases' => [
+            'asset' => AssetManager\View\Helper\Asset::class
+        ]
     ],
     'console'         => [
         'router' => [


### PR DESCRIPTION
fix #214

To work with the new introduced Zend ViewHelper `Zend\View\Helper\Asset` the configuration of AssetManager ViewHelper `asset` has to be changed.

@wshafer 