### PR TITLE
fixes unknown exception class

### DIFF
--- a/src/AssetManager/Resolver/AliasPathStackResolver.php
+++ b/src/AssetManager/Resolver/AliasPathStackResolver.php
@@ -7,7 +7,7 @@ use Assetic\Factory\Resource\DirectoryResource;
 use AssetManager\Exception;
 use AssetManager\Service\MimeResolver;
 use SplFileInfo;
-use Laminas\Db\TableGateway\Exception\RuntimeException;
+use AssetManager\Exception\RuntimeException;
 use Laminas\Stdlib\SplStack;
 
 /**


### PR DESCRIPTION
When a path is not existing/readable and `laminas/laminas-db` is not required within the project, the following error came up in my project:

```
======================================================================
   The application has thrown an exception!
======================================================================
 Error
 Class 'Zend\Db\TableGateway\Exception\RuntimeException' not found
----------------------------------------------------------------------
```

Imho this is just an automatically created `use` statement that should point to the `RuntimeException` class provided by this package 